### PR TITLE
feat: add score validation to soft skills

### DIFF
--- a/src/pages/EvaluateSoftSkillsSection.jsx
+++ b/src/pages/EvaluateSoftSkillsSection.jsx
@@ -11,6 +11,8 @@ export default function EvaluateSoftSkillsSection() {
   const [showSkillSection, setShowSkillSection] = useState(false);
   const [expandedSkills, setExpandedSkills] = useState({});
   const [expandedCategories, setExpandedCategories] = useState({});
+  const [errors, setErrors] = useState({});
+  const [formError, setFormError] = useState("");
 
   useEffect(() => {
     const fetchAthletes = async () => {
@@ -22,6 +24,35 @@ export default function EvaluateSoftSkillsSection() {
   }, []);
 
   const handleSubmit = async (skillName) => {
+    let hasError = false;
+    const updatedErrors = { ...errors };
+
+    for (const athlete of athletes) {
+      const rawScore = scores[athlete.id]?.[skillName];
+      if (rawScore !== undefined) {
+        const num = parseInt(rawScore, 10);
+        if (!Number.isInteger(num) || num < 1 || num > 5) {
+          if (!updatedErrors[athlete.id]) updatedErrors[athlete.id] = {};
+          updatedErrors[athlete.id][skillName] = true;
+          hasError = true;
+        } else if (updatedErrors[athlete.id]) {
+          delete updatedErrors[athlete.id][skillName];
+          if (Object.keys(updatedErrors[athlete.id]).length === 0) {
+            delete updatedErrors[athlete.id];
+          }
+        }
+      }
+    }
+
+    setErrors(updatedErrors);
+
+    if (hasError) {
+      setFormError("Please correct highlighted scores (1–5 only)");
+      return;
+    }
+
+    setFormError("");
+
     for (const athlete of athletes) {
       const score = parseInt(scores[athlete.id]?.[skillName]);
       if (!score || score < 1 || score > 5) continue;
@@ -38,6 +69,8 @@ export default function EvaluateSoftSkillsSection() {
     }
     alert(`✅ ${skillName} scores submitted!`);
     setScores({});
+    setErrors({});
+    setFormError("");
   };
 
   const toggleSkill = (skillName) => {
@@ -102,6 +135,9 @@ export default function EvaluateSoftSkillsSection() {
                         {isExpanded && (
                           <div className="p-4 space-y-3">
                             <p className="text-sm text-gray-600">{skill.definition}</p>
+                            {formError && (
+                              <p className="text-sm text-red-500">{formError}</p>
+                            )}
                             <table className="w-full text-sm border mb-4">
                               <thead>
                                 <tr className="bg-gray-100">
@@ -118,24 +154,58 @@ export default function EvaluateSoftSkillsSection() {
                                     <td className="p-2 border">{athlete.firstName}</td>
                                     <td className="p-2 border">{athlete.lastName}</td>
                                     <td className="p-2 border">
-                                      <input
-                                        type="number"
-                                        min="1"
-                                        max="5"
-                                        value={
-                                          scores[athlete.id]?.[skill.name] || ""
-                                        }
-                                        onChange={(e) =>
-                                          setScores((prev) => ({
-                                            ...prev,
-                                            [athlete.id]: {
-                                              ...prev[athlete.id],
-                                              [skill.name]: e.target.value,
-                                            },
-                                          }))
-                                        }
-                                        className="w-16 px-2 py-1 border rounded"
-                                      />
+                                      <div className="flex flex-col">
+                                        <input
+                                          type="number"
+                                          min="1"
+                                          max="5"
+                                          value={
+                                            scores[athlete.id]?.[skill.name] || ""
+                                          }
+                                          onChange={(e) => {
+                                            const value = e.target.value;
+                                            setScores((prev) => ({
+                                              ...prev,
+                                              [athlete.id]: {
+                                                ...prev[athlete.id],
+                                                [skill.name]: value,
+                                              },
+                                            }));
+                                            const num = parseInt(value, 10);
+                                            setErrors((prev) => {
+                                              const updated = { ...prev };
+                                              if (
+                                                !Number.isInteger(num) ||
+                                                num < 1 ||
+                                                num > 5
+                                              ) {
+                                                if (!updated[athlete.id])
+                                                  updated[athlete.id] = {};
+                                                updated[athlete.id][skill.name] = true;
+                                              } else if (updated[athlete.id]) {
+                                                delete updated[athlete.id][skill.name];
+                                                if (
+                                                  Object.keys(updated[athlete.id]).length === 0
+                                                ) {
+                                                  delete updated[athlete.id];
+                                                }
+                                              }
+                                              return updated;
+                                            });
+                                            if (formError) setFormError("");
+                                          }}
+                                          className={`w-16 px-2 py-1 border rounded ${
+                                            errors[athlete.id]?.[skill.name]
+                                              ? "border-red-500"
+                                              : ""
+                                          }`}
+                                        />
+                                        {errors[athlete.id]?.[skill.name] && (
+                                          <span className="text-xs text-red-500">
+                                            Score must be 1–5
+                                          </span>
+                                        )}
+                                      </div>
                                     </td>
                                   </tr>
                                 ))}


### PR DESCRIPTION
## Summary
- add error tracking and form-level validation for soft skill scoring
- highlight invalid inputs and show inline and summary error messages
- block submission of soft skill scores unless all entries are valid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689391f716e08329a0bfec685ee67fd5