### PR TITLE
Collect height and wingspan at registration

### DIFF
--- a/src/data/fitTestSkillsData.js
+++ b/src/data/fitTestSkillsData.js
@@ -1,20 +1,6 @@
 export const fitTestSkills = [
   {
     category: 'Fit Test',
-    name: 'Height',
-    units: 'inches',
-    min: 64.0,
-    max: 83.0
-  },
-  {
-    category: 'Fit Test',
-    name: 'Wingspan',
-    units: 'inches',
-    min: 66.0,
-    max: 88.0
-  },
-  {
-    category: 'Fit Test',
     name: 'Standing Vertical Jump',
     units: 'cm',
     min: 30.0,

--- a/src/pages/CoachDashboard_FilterExportView.jsx
+++ b/src/pages/CoachDashboard_FilterExportView.jsx
@@ -20,6 +20,8 @@ const skillCategories = {
 };
 
 const fitnessTests = {
+  "Height": "Height Percentile",
+  "Wingspan": "Wingspan Percentile",
   "Vertical Jump (cm)": "Vertical Jump Percentile",
   "20m Sprint (sec)": "Sprint Percentile",
   "T-Test Agility (sec)": "Agility Percentile",
@@ -31,6 +33,7 @@ const fitnessTests = {
 export default function CoachDashboard() {
   const [evaluations, setEvaluations] = useState([]);
   const [players, setPlayers] = useState([]);
+  const [athleteInfo, setAthleteInfo] = useState({});
   const [showNational, setShowNational] = useState(false);
   const [filters, setFilters] = useState({ grade: '', position: '' });
   const navigate = useNavigate();
@@ -42,6 +45,24 @@ export default function CoachDashboard() {
       setEvaluations(data);
     };
     fetchEvaluations();
+  }, []);
+
+  useEffect(() => {
+    const fetchAthletes = async () => {
+      const snap = await getDocs(collection(db, 'athletes'));
+      const info = {};
+      snap.docs.forEach(doc => {
+        const data = doc.data();
+        if (data.athleteId) {
+          info[data.athleteId] = {
+            height: data.height,
+            wingspan: data.wingspan,
+          };
+        }
+      });
+      setAthleteInfo(info);
+    };
+    fetchAthletes();
   }, []);
 
   useEffect(() => {
@@ -81,6 +102,12 @@ export default function CoachDashboard() {
           player[natField] = Math.round(natVals.reduce((a, b) => a + b, 0) / natVals.length);
       });
 
+      if (athleteInfo[id]) {
+        const info = athleteInfo[id];
+        if (info.height !== undefined) player['Height'] = info.height;
+        if (info.wingspan !== undefined) player['Wingspan'] = info.wingspan;
+      }
+
       return player;
     });
 
@@ -118,7 +145,7 @@ export default function CoachDashboard() {
     });
 
     setPlayers(summaries);
-  }, [evaluations]);
+  }, [evaluations, athleteInfo]);
 
   const filteredPlayers = players.filter(p => {
     const matchGrade = filters.grade ? p.grade === filters.grade : true;

--- a/src/pages/FitnessTestSection.jsx
+++ b/src/pages/FitnessTestSection.jsx
@@ -108,12 +108,8 @@ export default function FitnessTestSection() {
                         <th className="p-2 border">First</th>
                         <th className="p-2 border">Last</th>
                         <th className="p-2 border">Attempt 1</th>
-                        {skill.name !== "Height" && skill.name !== "Wingspan" && (
-                          <>
-                            <th className="p-2 border">Attempt 2</th>
-                            <th className="p-2 border">Attempt 3</th>
-                          </>
-                        )}
+                        <th className="p-2 border">Attempt 2</th>
+                        <th className="p-2 border">Attempt 3</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -126,12 +122,6 @@ export default function FitnessTestSection() {
                             <td className="p-2 border">{athlete.firstName}</td>
                             <td className="p-2 border">{athlete.lastName}</td>
                             {["Attempt 1", "Attempt 2", "Attempt 3"].map((label, i) => {
-                              if (
-                                (skill.name === "Height" ||
-                                  skill.name === "Wingspan") &&
-                                label !== "Attempt 1"
-                              )
-                                return null;
                               const attemptKey = `Attempt ${i + 1}`;
                               const value =
                                 evalData.attempts?.[attemptKey] ??

--- a/src/pages/TryoutRegistrationForm_Enhanced.jsx
+++ b/src/pages/TryoutRegistrationForm_Enhanced.jsx
@@ -9,6 +9,8 @@ export default function TryoutRegistrationForm() {
     firstName: '',
     lastName: '',
     jerseyNumberToday: '',
+    height: '',
+    wingspan: '',
     grade: '',
     birthdate: '',
     gender: '',
@@ -50,6 +52,8 @@ export default function TryoutRegistrationForm() {
 
     const data = {
       ...form,
+      height: form.height ? parseFloat(form.height) : null,
+      wingspan: form.wingspan ? parseFloat(form.wingspan) : null,
       athleteId: newAthleteId,
       orgId: orgId,
       timestamp: new Date()
@@ -62,6 +66,8 @@ export default function TryoutRegistrationForm() {
         firstName: '',
         lastName: '',
         jerseyNumberToday: '',
+        height: '',
+        wingspan: '',
         grade: '',
         birthdate: '',
         gender: '',
@@ -93,6 +99,8 @@ export default function TryoutRegistrationForm() {
         <input name="firstName" value={form.firstName} onChange={handleChange} placeholder="First Name" className="w-full p-2 border rounded" required />
         <input name="lastName" value={form.lastName} onChange={handleChange} placeholder="Last Name" className="w-full p-2 border rounded" required />
         <input name="jerseyNumberToday" value={form.jerseyNumberToday} onChange={handleChange} placeholder="Jersey Number (Today)" className="w-full p-2 border rounded" required />
+        <input type="number" step="any" name="height" value={form.height} onChange={handleChange} placeholder="Height (inches)" className="w-full p-2 border rounded" required />
+        <input type="number" step="any" name="wingspan" value={form.wingspan} onChange={handleChange} placeholder="Wingspan (inches)" className="w-full p-2 border rounded" required />
         <input name="grade" value={form.grade} onChange={handleChange} placeholder="Grade (e.g. 10)" className="w-full p-2 border rounded" required />
         <input type="date" name="birthdate" value={form.birthdate} onChange={handleChange} className="w-full p-2 border rounded" required />
 


### PR DESCRIPTION
## Summary
- remove height and wingspan from fit test metrics
- capture height and wingspan when players register
- surface registration height and wingspan metrics on coach dashboard and include in FP score

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6893d377aec883299b8ed1a37a076b77